### PR TITLE
Remove cache for index

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,11 +27,11 @@ jobs:
           path: ~/.cargo/registry
           key: cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      #- name: Cache cargo index
+      #  uses: actions/cache@v1
+      #  with:
+      #    path: ~/.cargo/git
+      #    key: cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo target dir
         uses: actions/cache@v1


### PR DESCRIPTION
We step was failing because we don't have any dependency in `~/.cargo/git`.